### PR TITLE
Added support for sending bounced emails to another address

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ General Postfix:
 - `RELAYHOST` -  Postfix `relayhost`. Default `empty`.
 - `POSTFIX_ADD_MISSING_HEADERS` - add missing headers. Default `no`
 - `INET_PROTOCOLS` - IP protocols, eg `ipv4` or `ipv6`. Default `all`
-- `BOUNCE_ADDRESS` - An email address to forward delivery failure messages onto. Default is to log the delivery failure.
+- `BOUNCE_ADDRESS` - Email address to receive delivery failure notifications. Default is to log the delivery failure.
 
 TLS parameters:
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ General Postfix:
 - `RELAYHOST` -  Postfix `relayhost`. Default `empty`.
 - `POSTFIX_ADD_MISSING_HEADERS` - add missing headers. Default `no`
 - `INET_PROTOCOLS` - IP protocols, eg `ipv4` or `ipv6`. Default `all`
+- `BOUNCE_ADDRESS` - An email address to forward delivery failure messages onto. Default is to log the delivery failure.
 
 TLS parameters:
 

--- a/s6/postfix/run
+++ b/s6/postfix/run
@@ -74,8 +74,8 @@ postconf -e always_add_missing_headers="$POSTFIX_ADD_MISSING_HEADERS"
 echo "postfix >> Setting inet_protocols to $INET_PROTOCOLS"
 postconf -e inet_protocols="$INET_PROTOCOLS"
 
-if [ "${BOUNCE_ADDRESS}x" != "x" ]; then
-  echo "postfix >> Setting bound address to $BOUNCE_ADDRESS"
+if [ -n "${BOUNCE_ADDRESS}" ]; then
+  echo "postfix >> Setting bounce address to $BOUNCE_ADDRESS"
   postconf -e notify_classes="bounce"
   postconf -e bounce_notice_recipient="$BOUNCE_ADDRESS"
 fi

--- a/s6/postfix/run
+++ b/s6/postfix/run
@@ -74,6 +74,12 @@ postconf -e always_add_missing_headers="$POSTFIX_ADD_MISSING_HEADERS"
 echo "postfix >> Setting inet_protocols to $INET_PROTOCOLS"
 postconf -e inet_protocols="$INET_PROTOCOLS"
 
+if [ "${BOUNCE_ADDRESS}x" != "x" ]; then
+  echo "postfix >> Setting bound address to $BOUNCE_ADDRESS"
+  postconf -e notify_classes="bounce"
+  postconf -e bounce_notice_recipient="$BOUNCE_ADDRESS"
+fi
+
 # exit cleanly
 trap "{ /usr/sbin/service postfix stop; }" EXIT
 


### PR DESCRIPTION
Hi,

I've added an environment variable which when set allows redirecting bounce messages to another email address. This avoids needing to constantly monitor logs to track bounced emails. 

Only really viable for low volume sites - but for something like my setup with a server with a few containers its really useful.

Thanks

jebw