### PR TITLE
set timezone if environment variable TZ exists

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-docker_tag 	= panubo/postfix:dev
+docker_tag 	= freinet/postfix-relay
 
 build:
 	docker build -t $(docker_tag) .

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-docker_tag 	= freinet/postfix-relay
+docker_tag 	= panubo/postfix:dev
 
 build:
 	docker build -t $(docker_tag) .

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ requires SMTP sending capabilities. Supports TLS out of the box and DKIM
 - `MAILNAME` - set this to a legitimate FQDN hostname for this service (required).
 - `MYNETWORKS` - comma separated list of IP subnets that are allowed to relay. Default `127.0.0.0/8, 10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16`
 - `LOGOUTPUT` - Syslog log file location. eg `/var/log/maillog`. Default `/dev/stdout`.
-- `TZ` - set timezone used by postfix to create `Received` headers. eg `Europe/Berlin`.
+- `TZ` - set timezone. This is used by Postfix to create `Received` headers. Default `UTC`.
 
 General Postfix:
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ requires SMTP sending capabilities. Supports TLS out of the box and DKIM
 General Postfix:
 
 - `SIZELIMIT` -  Postfix `message_size_limit`. Default `15728640`.
-- `RELAYHOST` -  Postfix `relayhost`. Default `empty`.
+- `RELAYHOST` -  Postfix `relayhost`. Default ''.
 - `POSTFIX_ADD_MISSING_HEADERS` - add missing headers. Default `no`
 - `INET_PROTOCOLS` - IP protocols, eg `ipv4` or `ipv6`. Default `all`
 - `BOUNCE_ADDRESS` - Email address to receive delivery failure notifications. Default is to log the delivery failure.

--- a/entry.sh
+++ b/entry.sh
@@ -16,8 +16,9 @@ fi
 
 # Set timezone if given
 if [ ! -z "$TZ" ]; then
-    ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
-    echo "smtp >> Info: setting timezone to $TZ"
+    echo "smtp >> Info: setting timezone to ${TZ}"
+    ln -snf "/usr/share/zoneinfo/${TZ}" /etc/localtime
+    echo "${TZ}" > /etc/timezone
 fi
 
 echo "Running command $@"

--- a/entry.sh
+++ b/entry.sh
@@ -14,5 +14,11 @@ if [ -z "$MYNETWORKS" ]; then
     echo "smtp >> Warning: MYNETWORKS not specified, allowing all private IPs"
 fi
 
+# Set timezone if given
+if [ ! -z "$TZ" ]; then
+    ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
+    echo "smtp >> Info: setting timezone to $TZ"
+fi
+
 echo "Running command $@"
 exec "$@"

--- a/entry.sh
+++ b/entry.sh
@@ -14,8 +14,8 @@ if [ -z "$MYNETWORKS" ]; then
     echo "smtp >> Warning: MYNETWORKS not specified, allowing all private IPs"
 fi
 
-# Set timezone if given
-if [ ! -z "$TZ" ]; then
+# Set timezone if set
+if [ ! -z "${TZ}" ]; then
     echo "smtp >> Info: setting timezone to ${TZ}"
     ln -snf "/usr/share/zoneinfo/${TZ}" /etc/localtime
     echo "${TZ}" > /etc/timezone


### PR DESCRIPTION
this way postfix and rsyslog use the given timezone when generating timestamps