### PR TITLE
extend postfix run script to support postconf configuration of 'virtu…

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@ Postfix SMTP Relay.
 
 Drop-in Docker image for SMTP relaying. Use wherever a connected service
 requires SMTP sending capabilities. Supports TLS out of the box and DKIM
-(if enabled and configured).
+(if enabled and configured). Additionally offers support for Virtual
+alias regex (useful for address rewriting) and maps.
 
 ## Environment Variables
 
@@ -15,7 +16,7 @@ requires SMTP sending capabilities. Supports TLS out of the box and DKIM
 
 General Postfix:
 
-- `SIZELIMIT` -  Postfix `message_size_limit`. Default `15728640`.
+- `SIZELIMIT` - Postfix `message_size_limit`. Default `15728640`.
 - `POSTFIX_ADD_MISSING_HEADERS` - add missing headers. Default `no`
 - `INET_PROTOCOLS` - IP protocols, eg `ipv4` or `ipv6`. Default `all`
 - `BOUNCE_ADDRESS` - Email address to receive delivery failure notifications. Default is to log the delivery failure.
@@ -26,6 +27,11 @@ Relay host parameters:
 - `RELAYHOST` - Postfix `relayhost`. Default ''. (example `mail.example.com:25`)
 - `RELAYHOST_AUTH` - Enable authentication for relayhost. Generally used with `RELAYHOST_PASSWORDMAP`. Default `no`.
 - `RELAYHOST_PASSWORDMAP` - relayhost password map in format: `RELAYHOST_PASSWORDMAP=mail1.example.com:user1:pass2,mail2.example.com:user2:pass2`
+
+Virtual parameters:
+
+- `VIRTUAL_ALIAS_MAP` - virtual alias map in format: `VIRTUAL_ALIAS_MAP=someone@somewhere.com:local_user,postmaster@example.net:root`
+- `VIRTUAL_ALIAS_REGEX_BASE64` - virtual alias regex base64 encoded. (example `VIRTUAL_ALIAS_REGEX_BASE64=aWYgIS8uKmV4YW1wbGUuY29tLwovLiovIHJlZGlyZWN0LWFkZHJlc3NAc29tZXdoZXJlLm5ldAplbmRpZgo=`)
 
 TLS parameters:
 

--- a/s6/postfix/run
+++ b/s6/postfix/run
@@ -106,6 +106,36 @@ if [ -n "${RELAYHOST_PASSWORDMAP}" ]; then
     postmap hash:/etc/postfix/sasl-passwords
 fi
 
+# Virtual Alias Maps - supporting reading alias map or base64 encoded regex style
+if [ -n "${VIRTUAL_ALIAS_MAP}" ] || [ -n "${VIRTUAL_ALIAS_REGEX_BASE64}" ]; then
+    declare -a postconf_alias_maps
+    if [ -n "${VIRTUAL_ALIAS_MAP}" ]; then
+        echo "postfix >> Generating virtual host map"
+        truncate --size 0 /etc/postfix/virtual
+        IFS=',' read -r -a ALIASMAP <<< "${VIRTUAL_ALIAS_MAP}"
+        for A in "${ALIASMAP[@]}"; do
+            IFS=':' read -ra MAP <<< "$A"
+            VIRT=${MAP[0]}
+            DEST=${MAP[1]}
+            echo "postfix >> Adding virtual ${VIRT} to map to dest: ${DEST}."
+            echo "${VIRT} ${DEST}" >> /etc/postfix/virtual
+        done
+        postmap hash:/etc/postfix/virtual
+        postconf_alias_maps+=(hash:/etc/postfix/virtual)
+    fi
+    if [ -n "${VIRTUAL_ALIAS_REGEX_BASE64}" ]; then
+        echo "postfix >> Base64 decoding '${VIRTUAL_ALIAS_REGEX_BASE64}' into file /etc/postfix/virtual-regex"
+        truncate --size 0 /etc/postfix/virtual-regex
+        echo $VIRTUAL_ALIAS_REGEX_BASE64 | base64 -d >> /etc/postfix/virtual-regex
+        postmap /etc/postfix/virtual-regex
+        postconf_alias_maps+=(regexp:/etc/postfix/virtual-regex)
+    fi
+    echo "postfix >> Configuring postconf virtual_alias_maps"
+    combined_val=$(printf ",%s" "${postconf_alias_maps[@]}")
+    combined_val=${combined_val:1}
+    postconf -e virtual_alias_maps=$combined_val
+fi
+
 echo "postfix >> Setting always_add_missing_headers to ${POSTFIX_ADD_MISSING_HEADERS}"
 postconf -e always_add_missing_headers="${POSTFIX_ADD_MISSING_HEADERS}"
 


### PR DESCRIPTION
…al_alias_maps' for both traditional virtual map and regex (base64 encoded).

The regex extension (base64 encoded) is useful because one can use it to create ad-hoc rewrite rules for the relay.