### PR TITLE
Revert relayhost passwordmap delimiter

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Relay host parameters:
 
 - `RELAYHOST` - Postfix `relayhost`. Default ''. (example `mail.example.com:25`, or `[email-smtp.us-west-2.amazonaws.com]:587`)
 - `RELAYHOST_AUTH` - Enable authentication for relayhost. Generally used with `RELAYHOST_PASSWORDMAP`. Default `no`. Values `yes|no`.
-- `RELAYHOST_PASSWORDMAP` - relayhost password map in format: `RELAYHOST_PASSWORDMAP=mail1.example.com:587|user1|pass2,mail2.example.com|user2|pass2`. Note: Delimiter usage has changed.
+- `RELAYHOST_PASSWORDMAP` - relayhost password map in format: `RELAYHOST_PASSWORDMAP=[mail1.example.com]:587:user1:pass2,mail2.example.com:user2:pass2`.
 
 TLS parameters:
 

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ docker run --rm -t -i \
   -e MAILNAME=mail1.example.com \
   -e RELAYHOST_AUTH='yes' \
   -e RELAYHOST='[smtp.sendgrid.net]:587' \
-  -e RELAYHOST_PASSWORDMAP="[smtp.sendgrid.net]:587|apikey|<apikey goes here>" \
+  -e RELAYHOST_PASSWORDMAP="[smtp.sendgrid.net]:587:apikey:<apikey goes here>" \
   panubo/postfix:latest
 ```
 

--- a/s6/postfix/run
+++ b/s6/postfix/run
@@ -96,10 +96,19 @@ if [ -n "${RELAYHOST_PASSWORDMAP}" ]; then
     truncate --size 0 /etc/postfix/sasl-passwords
     IFS=',' read -r -a PASSWORDMAP <<< "${RELAYHOST_PASSWORDMAP}"
     for P in "${PASSWORDMAP[@]}"; do
-        IFS='|' read -ra MAP <<< "$P"
-        HOST=${MAP[0]}
-        USER=${MAP[1]}
-        PASS=${MAP[2]}
+        IFS=':' read -ra MAP <<< "$P"
+        if [[ "${#MAP[@]}" -eq 3 ]]; then
+          HOST=${MAP[0]}
+          USER=${MAP[1]}
+          PASS=${MAP[2]}
+        elif [[ "${#MAP[@]}" -eq 4 ]]; then
+          HOST="${MAP[0]}:${MAP[1]}"
+          USER=${MAP[2]}
+          PASS=${MAP[3]}
+        else
+          echo "Bad password map"
+          exit 1
+        fi
         echo "postfix >> Adding user ${HOST} with user: ${USER}."
         echo "${HOST} ${USER}:${PASS}" >> /etc/postfix/sasl-passwords
     done


### PR DESCRIPTION
I don't think pipe or semicolon make good delimiter as they can easily get interpreted by the shell. Colon is also a common delimiter for username password.

Refs #13