### PR TITLE
Add option to specify passwordmap file and smtpd users file

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,12 +37,14 @@ These are common parameters to rate limit outbound mail:
 - `RELAYHOST` - Postfix relay host. Default ''. (example `mail.example.com:25`, or `[email-smtp.us-west-2.amazonaws.com]:587`). N.B. Use square brackets to prevent MX lookup on relay hostname.
 - `RELAYHOST_AUTH` - Enable authentication for relay host. Generally used with `RELAYHOST_PASSWORDMAP`. Default `no`. (options, `yes`, `no`).
 - `RELAYHOST_PASSWORDMAP` - relay host password map in format: `RELAYHOST_PASSWORDMAP=[mail1.example.com]:587:user1:pass2,mail2.example.com:user2:pass2`.
+- `RELAYHOST_PASSWORDMAP_FILE` - relayhost password map file, content is copied into RELAYHOST_PASSWORDMAP. Useful in combination with docker secrets.
 
 **Client authentication parameters:**
 
 Client authentication is used to authenticate relay clients. Client authentication can be used in conjunction with, or as an alternative to `MYNETWORKS`.
 
 - `SMTPD_USERS` - SMTPD Users `user1:password1,user2:password2`
+- `SMTPD_USERS_FILE` - SMTPD Users in a file, content is copied into SMTPD_USERS. Useful in combination with docker secrets.
 
 **TLS parameters:**
 

--- a/s6/postfix/run
+++ b/s6/postfix/run
@@ -91,6 +91,16 @@ if [ "${RELAYHOST_AUTH}" == "yes" ]; then
     postconf -e smtp_sasl_mechanism_filter="PLAIN LOGIN"
 fi
 
+if [ -n "${RELAYHOST_PASSWORDMAP_FILE}" ]; then
+  echo "postfix >> Reading password map file: ${RELAYHOST_PASSWORDMAP_FILE}"
+  if [ -e "${RELAYHOST_PASSWORDMAP_FILE}" ]; then
+    RELAYHOST_PASSWORDMAP=$(cat $RELAYHOST_PASSWORDMAP_FILE)
+    echo "postfix >> Read password map file"
+  else
+    echo "postfix >> Specified password map file not found!"
+  fi
+fi
+
 if [ -n "${RELAYHOST_PASSWORDMAP}" ]; then
     echo "postfix >> Generating relayhost password map"
     truncate --size 0 /etc/postfix/sasl-passwords
@@ -149,6 +159,16 @@ if [ ! -z "${SMTP_EXTRA_RECIPIENT_LIMIT}" ]; then
 fi
 
 # Client Authentication (SASL)
+if [ -n "${SMTPD_USERS_FILE}" ]; then
+  echo "postfix >> Reading SMTPD users file: ${SMTPD_USERS_FILE}"
+  if [ -e "${SMTPD_USERS_FILE}" ]; then
+    SMTPD_USERS=$(cat $SMTPD_USERS_FILE)
+    echo "postfix >> Read SMTPD users file"
+  else
+    echo "postfix >> Specified SMTPD users file not found!"
+  fi
+fi
+
 if [ ! -z "${SMTPD_USERS}" ]; then
   echo "postfix >> Setting smtpd sasl auth"
   postconf -e smtpd_sasl_auth_enable="yes"


### PR DESCRIPTION
This PR allows you to specify the RELAYHOST_PASSWORDMAP and SMTPD_USERS in a file so it can be used with docker secrets as follows:

docker-compose.yml:
```yaml
services:
  postfix:
    image: ....
    environment:
      RELAY_AUTH: 'yes'
      RELAYHOST_PASSWORDMAP_FILE: /run/secrets/relay_passwordmap
      SMTPD_USERS_FILE: /run/secrets/smtpd_users
secrets:
  relay_passwordmap:
    external: true
  smtpd_users:
    external: true
```