### PR TITLE
Revert "Fix sendgrid RELAYHOST_PASSWORDMAP"

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ docker run --rm -t -i \
   -e MAILNAME=mail1.example.com \
   -e RELAYHOST_AUTH='yes' \
   -e RELAYHOST='[smtp.sendgrid.net]:587' \
-  -e RELAYHOST_PASSWORDMAP="[smtp.sendgrid.net]:587,apikey,<apikey goes here>" \
+  -e RELAYHOST_PASSWORDMAP="[smtp.sendgrid.net]:587:apikey:<apikey goes here>" \
   panubo/postfix:latest
 ```
 


### PR DESCRIPTION
This reverts commit 40104e1424533bd4a9b99f9d3a91a14ed701d638.

According to the "new" code ":" is the proper separator: https://github.com/panubo/docker-postfix/blob/04878d3e76a4aaf82b950aa39cf5ce3ac919ba64/s6/postfix/run#L99