### PR TITLE
Fixed postfix warning about makedefs.out.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,6 +41,7 @@ RUN set -x \
   && postconf -e smtpd_banner="\$myhostname ESMTP" \
   && postconf -Me submission/inet="submission inet n - y - - smtpd" \
   && postconf -Me 2525/inet="2525 inet n - y - - smtpd" \
+  && cp --remove-destination /usr/share/postfix/makedefs.out /etc/postfix/makedefs.out \
   && cp -a /var/spool/postfix /var/spool/postfix.cache \
   && rm -f /etc/ssl/private/ssl-cert-snakeoil.key /etc/ssl/certs/ssl-cert-snakeoil.pem \
   && rm -f /etc/opendkim.conf \


### PR DESCRIPTION
This removes the warning generated on startup:

postfix >> Checking Postfix Configuration
postfix/postfix-script: warning: symlink leaves directory: /etc/postfix/./makedefs.out
Jun 29 11:23:22 postfix/postfix-script[1036]: warning: symlink leaves directory: /etc/postfix/./makedefs.out
postfix/postfix-script: warning: symlink leaves directory: /etc/postfix/./makedefs.out
Jun 29 11:23:22 postfix/postfix-script[1263]: warning: symlink leaves directory: /etc/postfix/./makedefs.out
postfix/postfix-script: starting the Postfix mail system