### PR TITLE
Add sender dependent relayhost authentication, client TLS, and upgrade base

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # Postfix SMTP Relay
 
-FROM debian:buster
+FROM debian:bullseye
 
 EXPOSE 25 587 2525
 
@@ -23,11 +23,11 @@ RUN set -x \
 
 # Install s6
 RUN set -x \
-  && S6_VERSION=2.8.0.0 \
-  && S6_CHECKSUM=c3985d90f4abad285b45b7fb6680ac02c266e08ccf85f9dc55123b2e2faf1579 \
-  && EXECLINE_VERSION=2.5.1.0 \
-  && EXECLINE_CHECKSUM=b26e6b4c09ddf0dc8162876376f5fbf0e807997513fd647dfa26de99cff29720 \
-  && SKAWARE_RELEASE=1.22.2 \
+  && S6_VERSION=2.11.0.0 \
+  && S6_CHECKSUM=fcf79204c1957016fc88b0ad7d98f150071483583552103d5822cbf56824cc87 \
+  && EXECLINE_VERSION=2.8.1.0 \
+  && EXECLINE_CHECKSUM=b216cfc4db928729d950df5a354aa34bc529e8250b55ab0de700193693dea682 \
+  && SKAWARE_RELEASE=2.0.7 \
   && curl -sSf -L https://github.com/just-containers/skaware/releases/download/v${SKAWARE_RELEASE}/s6-${S6_VERSION}-linux-amd64-bin.tar.gz -o /tmp/s6-${S6_VERSION}-linux-amd64-bin.tar.gz \
   && curl -sSf -L https://github.com/just-containers/skaware/releases/download/v${SKAWARE_RELEASE}/execline-${EXECLINE_VERSION}-linux-amd64-bin.tar.gz -o /tmp/execline-${EXECLINE_VERSION}-linux-amd64-bin.tar.gz \
   && printf "%s  %s\n" "${S6_CHECKSUM}" "s6-${S6_VERSION}-linux-amd64-bin.tar.gz" "${EXECLINE_CHECKSUM}" "execline-${EXECLINE_VERSION}-linux-amd64-bin.tar.gz" > /tmp/SHA256SUM \

--- a/README.md
+++ b/README.md
@@ -36,7 +36,9 @@ These are common parameters to rate limit outbound mail:
 
 - `RELAYHOST` - Postfix relay host. Default ''. (example `mail.example.com:25`, or `[email-smtp.us-west-2.amazonaws.com]:587`). N.B. Use square brackets to prevent MX lookup on relay hostname.
 - `RELAYHOST_AUTH` - Enable authentication for relay host. Generally used with `RELAYHOST_PASSWORDMAP`. Default `no`. (options, `yes`, `no`).
-- `RELAYHOST_PASSWORDMAP` - relay host password map in format: `RELAYHOST_PASSWORDMAP=[mail1.example.com]:587:user1:pass2,mail2.example.com:user2:pass2`.
+- `RELAYHOST_PASSWORDMAP` - Relay host password map in format: `RELAYHOST_PASSWORDMAP=[mail1.example.com]:587:user1:pass1,mail2.example.com:user2:pass2,user3:pass3`.
+- `RELAYHOST_MAP` - Sender dependent relayhost map in format: `RELAYHOST_MAP=@domain1.com:smtp.example.com:587,@domain2.com:[smtp.example.com]:587`
+- `SENDER_DEPENDENT_RELAYHOST_AUTH` - Enable sender dependent authentication for relay host. Generally used with `RELAYHOST_MAP` and `RELAYHOST_PASSWORDMAP`. Default `no`. (options, `yes`, `no`).
 
 **Client authentication parameters:**
 
@@ -51,6 +53,10 @@ Client authentication is used to authenticate relay clients. Client authenticati
 - `TLS_KEY` - Default `/etc/ssl/private/ssl-cert-snakeoil.key`
 - `TLS_CRT` - Default `/etc/ssl/certs/ssl-cert-snakeoil.pem`
 - `TLS_CA` - Default ''
+
+- `CLIENT_TLS_SECURITY_LEVEL` - Default `may` same as TLS_SECURITY_LEVEL but for client tls
+- `CLIENT_TLS_KEY` - Default `/etc/ssl/private/ssl-cert-snakeoil.key`
+- `CLIENT_TLS_CRT` - Default `/etc/ssl/certs/ssl-cert-snakeoil.pem`
 
 NB. A self-signed ("snake-oil") certificate will be generated on start if required.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Postfix Docker Image
 
-Postfix SMTP Relay based on Debian Buster.
+Postfix SMTP Relay based on Debian Bullseye.
 
 Highly configurable Docker image for SMTP relaying. Use wherever a connected service
 requires SMTP sending capabilities. Supports TLS out of the box and DKIM

--- a/s6/postfix/run
+++ b/s6/postfix/run
@@ -121,11 +121,7 @@ if [ -n "${RELAYHOST_PASSWORDMAP}" ]; then
     IFS=',' read -r -a PASSWORDMAP <<< "${RELAYHOST_PASSWORDMAP}"
     for P in "${PASSWORDMAP[@]}"; do
         IFS=':' read -ra MAP <<< "$P"
-        if [[ "${#MAP[@]}" -eq 2 ]]; then
-          HOST=${MAP[0]}
-          USER=${MAP[0]}
-          PASS=${MAP[1]}
-        elif [[ "${#MAP[@]}" -eq 3 ]]; then
+        if [[ "${#MAP[@]}" -eq 3 ]]; then
           HOST=${MAP[0]}
           USER=${MAP[1]}
           PASS=${MAP[2]}

--- a/s6/postfix/run
+++ b/s6/postfix/run
@@ -14,6 +14,9 @@ set -e
 : "${TLS_KEY:=/etc/ssl/private/ssl-cert-snakeoil.key}"
 : "${TLS_CRT:=/etc/ssl/certs/ssl-cert-snakeoil.pem}"
 : "${TLS_CA:=}"
+: "${CLIENT_TLS_SECURITY_LEVEL:=may}"
+: "${CLIENT_TLS_KEY:=/etc/ssl/private/ssl-cert-snakeoil.key}"
+: "${CLIENT_TLS_CRT:=/etc/ssl/certs/ssl-cert-snakeoil.pem}"
 
 # General
 : "${POSTFIX_ADD_MISSING_HEADERS:=no}"
@@ -54,7 +57,9 @@ if [ "${USE_TLS}" == "yes" ]; then
     fi
     echo "postfix >> Setting smtp_tls parameters"
     # setting smtpd_tls_security_level implies smtp_use_tls="yes"
-    postconf -e smtp_tls_security_level="${TLS_SECURITY_LEVEL}"
+    postconf -e smtp_tls_security_level="${CLIENT_TLS_SECURITY_LEVEL}"
+    postconf -e smtp_tls_key_file="${CLIENT_TLS_KEY}"
+    postconf -e smtp_tls_cert_file="${CLIENT_TLS_CRT}"
     postconf -e smtp_tls_CApath="/etc/ssl/certs"
     postconf -e smtp_tls_loglevel="1"
     echo "postfix >> Setting smtpd_tls parameters"
@@ -94,13 +99,33 @@ if [ "${RELAYHOST_AUTH}" == "yes" ]; then
     postconf -e smtp_sasl_mechanism_filter="PLAIN LOGIN"
 fi
 
+if [ "${SENDER_DEPENDENT_RELAYHOST_AUTH}" == "yes" ]; then
+    echo "postfix >> Enabling sender dependent relayhost authentication"
+    touch /etc/postfix/relayhost-map
+    touch /etc/postfix/sasl-passwords
+    # postconf -# relayhost
+    postconf -e smtp_sasl_auth_enable=yes
+    postconf -e smtp_sasl_security_options=noanonymous
+    postconf -e smtp_sasl_password_maps=hash:/etc/postfix/sasl-passwords
+    postconf -e smtp_sender_dependent_authentication=yes
+    postconf -e sender_dependent_relayhost_maps=hash:/etc/postfix/relayhost-map
+    # require encryption with relayhost auth
+    postconf -e smtp_use_tls=yes
+    postconf -e smtp_tls_security_level=encrypt
+    postconf -e smtp_sasl_mechanism_filter="PLAIN LOGIN"
+fi
+
 if [ -n "${RELAYHOST_PASSWORDMAP}" ]; then
     echo "postfix >> Generating relayhost password map"
     truncate --size 0 /etc/postfix/sasl-passwords
     IFS=',' read -r -a PASSWORDMAP <<< "${RELAYHOST_PASSWORDMAP}"
     for P in "${PASSWORDMAP[@]}"; do
         IFS=':' read -ra MAP <<< "$P"
-        if [[ "${#MAP[@]}" -eq 3 ]]; then
+        if [[ "${#MAP[@]}" -eq 2 ]]; then
+          HOST=${MAP[0]}
+          USER=${MAP[0]}
+          PASS=${MAP[1]}
+        elif [[ "${#MAP[@]}" -eq 3 ]]; then
           HOST=${MAP[0]}
           USER=${MAP[1]}
           PASS=${MAP[2]}
@@ -116,6 +141,26 @@ if [ -n "${RELAYHOST_PASSWORDMAP}" ]; then
         echo "${HOST} ${USER}:${PASS}" >> /etc/postfix/sasl-passwords
     done
     postmap hash:/etc/postfix/sasl-passwords
+fi
+
+if [ -n "${RELAYHOST_MAP}" ]; then
+    echo "postfix >> Generating relayhost map"
+    truncate --size 0 /etc/postfix/relayhost-map
+    IFS=',' read -r -a RELAYHOSTMAP <<< "${RELAYHOST_MAP}"
+    for P in "${RELAYHOSTMAP[@]}"; do
+        IFS=':' read -ra MAP <<< "$P"
+        if [[ "${#MAP[@]}" -eq 3 ]]; then
+          FROM=${MAP[0]}
+          HOST=${MAP[1]}
+          PORT=${MAP[2]}
+        else
+          echo "Bad relayhost map"
+          exit 1
+        fi
+        echo "postfix >> Adding from ${FROM} with smtp: ${HOST}:${PORT}."
+        echo "${FROM} ${HOST}:${PORT}" >> /etc/postfix/relayhost-map
+    done
+    postmap hash:/etc/postfix/relayhost-map
 fi
 
 echo "postfix >> Setting always_add_missing_headers to ${POSTFIX_ADD_MISSING_HEADERS}"


### PR DESCRIPTION
- Incorporate https://github.com/panubo/docker-postfix/pull/30
- Incorporate https://github.com/panubo/docker-postfix/pull/40
- Update Dockerfile image base from Debian buster to Debian bullseye
- Update s6 service supervisor