### PR TITLE
Remove default config for smtpd_tls_cert_file and smtpd_tls_key_file to avoid warning message in logs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,6 +45,7 @@ RUN set -x \
   && cp --remove-destination /usr/share/postfix/makedefs.out /etc/postfix/makedefs.out \
   && cp -a /var/spool/postfix /var/spool/postfix.cache \
   && rm -f /etc/ssl/private/ssl-cert-snakeoil.key /etc/ssl/certs/ssl-cert-snakeoil.pem \
+  && sed -i -E '/^smtpd_tls_cert_file|^smtpd_tls_key_file/d' /etc/postfix/main.cf \
   && rm -f /etc/opendkim.conf \
   && mkdir /etc/opendkim/ \
   ;


### PR DESCRIPTION
When TLS is not used, if we let default configuration:

```
smtpd_tls_cert_file=/etc/ssl/certs/ssl-cert-snakeoil.pem
smtpd_tls_key_file=/etc/ssl/private/ssl-cert-snakeoil.key
```

These warning messages appears in /var/log/maillog:

```
Jul 29 14:24:01 postfix/smtpd[24123]: warning: cannot get RSA certificate from file "/etc/ssl/certs/ssl-cert-snakeoil.pem": disabling TLS support
Jul 29 14:24:01 postfix/smtpd[24123]: warning: TLS library problem: error:02001002:system library:fopen:No such file or directory:../crypto/bio/bss_file.c:288:fopen('/etc/ssl/certs/ssl-cert-snakeoil.pem','r'):
Jul 29 14:24:01 postfix/smtpd[24123]: warning: TLS library problem: error:20074002:BIO routines:file_ctrl:system lib:../crypto/bio/bss_file.c:290:
Jul 29 14:24:01 postfix/smtpd[24123]: warning: TLS library problem: error:140DC002:SSL routines:use_certificate_chain_file:system lib:../ssl/ssl_rsa.c:596:
```

As these files are removed from Dockerfile command, we must remove these ones from main.cf default configuration.
