### PR TITLE
Upgrade to debian 12 and add postfix_exporter

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,7 @@ RUN set -x \
 RUN set -x \
   && export DEBIAN_FRONTEND=noninteractive \
   && apt-get update \
-  && apt-get install -y --no-install-recommends postfix mailutils busybox-syslogd opendkim opendkim-tools libsasl2-modules sasl2-bin curl ca-certificates procps s6 \
+  && apt-get install -y --no-install-recommends postfix mailutils busybox-syslogd opendkim opendkim-tools libsasl2-modules sasl2-bin curl ca-certificates procps s6 inotify-tools \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/* \
   ;

--- a/Makefile
+++ b/Makefile
@@ -2,37 +2,43 @@ NAME := postfix
 TAG := latest
 IMAGE_NAME := panubo/$(NAME)
 
-.PHONY: *
+.PHONY: help bash run run-* build push clean _ci_test
 
 help:
 	@printf "$$(grep -hE '^\S+:.*##' $(MAKEFILE_LIST) | sed -e 's/:.*##\s*/:/' -e 's/^\(.\+\):\(.*\)/\\x1b[36m\1\\x1b[m:\2/' | column -c2 -t -s :)\n"
 
 bash: ## Runs a bash shell in the docker image
-	docker run --rm -it -e MAILNAME=mail.example.com $(IMAGE_NAME):latest bash
+	docker run --rm -it -e MAILNAME=mail.example.com $(IMAGE_NAME):$(TAG) bash
 
 run: ## Runs the docker image in a test mode
-	$(eval ID := $(shell docker run -d --name postfix -e RELAYHOST=172.17.0.2 -e MAILNAME=mail.example.com -e SIZELIMIT=20480000 -e LOGOUTPUT=/var/log/maillog $(IMAGE_NAME):latest))
+	$(eval ID := $(shell docker rm -f $(NAME) >/dev/null 2>&1; docker run -d --name $(NAME) --hostname mail.example.com \
+		-e RELAYHOST=172.17.0.2 \
+		-e MAILNAME=mail.example.com \
+		-e SIZELIMIT=20480000 \
+		-e LOGOUTPUT=/var/log/maillog \
+		-e POSTFIX_EXPORTER_ENABLED=false $(IMAGE_NAME):$(TAG)))
 	$(eval IP := $(shell docker inspect --format '{{ .NetworkSettings.IPAddress }}' ${ID}))
 	@echo "Running ${ID} @ smtp://${IP}"
 	@docker attach ${ID}
 	@docker kill ${ID}
 
-run-tls: ## Runs the docker image in a test mode with TLS
-		$(eval ID := $(shell docker run -d --name postfix --hostname mail.example.com -e RELAYHOST=172.17.0.2 -e MAILNAME=mail.example.com -e USE_TLS=yes $(IMAGE_NAME):latest))
-		$(eval IP := $(shell docker inspect --format '{{ .NetworkSettings.IPAddress }}' ${ID}))
-		@echo "Running ${ID} @ smtp://${IP}"
-		@docker attach ${ID}
-		@docker kill ${ID}
-
-run-dkim: ## Runs the docker image in a test mode with DKIM
-	$(eval ID := $(shell docker run -d --name postfix --hostname mail.example.com -e RELAYHOST=172.17.0.2 -e MAILNAME=mail.example.com -e DKIM_DOMAINS=foo.example.com,bar.example.com,example.net -e USE_DKIM=yes -v `pwd`/dkim.key:/etc/opendkim/dkim.key $(IMAGE_NAME):latest))
+run-dkim: dkim.key ## Runs the docker image in a test mode with DKIM
+	$(eval ID := $(shell docker rm -f $(NAME) >/dev/null 2>&1; docker run -d --name $(NAME) --hostname mail.example.com \
+		-e RELAYHOST=172.17.0.2 \
+		-e MAILNAME=mail.example.com \
+		-e USE_DKIM=yes -v `pwd`/dkim.key:/etc/opendkim/dkim.key $(IMAGE_NAME):$(TAG)))
 	$(eval IP := $(shell docker inspect --format '{{ .NetworkSettings.IPAddress }}' ${ID}))
 	@echo "Running ${ID} @ smtp://${IP}"
 	@docker attach ${ID}
 	@docker kill ${ID}
 
-run-all-dkim: ## Runs the docker image in a test mode. All settings
-	$(eval ID := $(shell docker run -d --name postfix --hostname mail.example.com -e RELAYHOST=172.17.0.2 -e MAILNAME=mail.example.com -e DKIM_DOMAINS=foo.example.com,bar.example.com,example.net -e DKIM_SELECTOR=6091aa68-f43d-47cf-a52e-bafda525d0bc -e USE_DKIM=yes -v `pwd`/dkim.key:/etc/opendkim/dkim.key $(IMAGE_NAME):latest))
+run-all-dkim: dkim.key ## Runs the docker image in a test mode. All settings
+	$(eval ID := $(shell docker rm -f $(NAME) >/dev/null 2>&1; docker run -d --name $(NAME) --hostname mail.example.com \
+		-e RELAYHOST=172.17.0.2 \
+		-e MAILNAME=mail.example.com \
+		-e DKIM_DOMAINS=foo.example.com,bar.example.com,example.net \
+		-e DKIM_SELECTOR=6091aa68-f43d-47cf-a52e-bafda525d0bc \
+		-e USE_DKIM=yes -v `pwd`/dkim.key:/etc/opendkim/dkim.key $(IMAGE_NAME):$(TAG)))
 	$(eval IP := $(shell docker inspect --format '{{ .NetworkSettings.IPAddress }}' ${ID}))
 	@echo "Running ${ID} @ smtp://${IP}"
 	@docker attach ${ID}
@@ -49,3 +55,6 @@ clean: ## Remove built image
 
 _ci_test:
 	true
+
+dkim.key:
+	openssl genrsa -out dkim.key 2048

--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,7 @@ run: ## Runs the docker image in a test mode
 		-e MAILNAME=mail.example.com \
 		-e SIZELIMIT=20480000 \
 		-e LOGOUTPUT=/var/log/maillog \
+		-e CONFIG_RELOADER_ENABLED=true \
 		-e POSTFIX_EXPORTER_ENABLED=false $(IMAGE_NAME):$(TAG)))
 	$(eval IP := $(shell docker inspect --format '{{ .NetworkSettings.IPAddress }}' ${ID}))
 	@echo "Running ${ID} @ smtp://${IP}"
@@ -26,6 +27,7 @@ run-dkim: dkim.key ## Runs the docker image in a test mode with DKIM
 	$(eval ID := $(shell docker rm -f $(NAME) >/dev/null 2>&1; docker run -d --name $(NAME) --hostname mail.example.com \
 		-e RELAYHOST=172.17.0.2 \
 		-e MAILNAME=mail.example.com \
+		-e CONFIG_RELOADER_ENABLED=true \
 		-e USE_DKIM=yes -v `pwd`/dkim.key:/etc/opendkim/dkim.key $(IMAGE_NAME):$(TAG)))
 	$(eval IP := $(shell docker inspect --format '{{ .NetworkSettings.IPAddress }}' ${ID}))
 	@echo "Running ${ID} @ smtp://${IP}"

--- a/README.md
+++ b/README.md
@@ -15,8 +15,9 @@ This image is available on quay.io `quay.io/panubo/postfix` and AWS ECR Public `
 
 - `MAILNAME` - set this to a legitimate FQDN hostname for this service (required). (example, `mail.example.com`)
 - `MYNETWORKS` - comma separated list of IP subnets that are allowed to relay. Default `127.0.0.0/8, 10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16`
-- `LOGOUTPUT` - Syslog log file location. eg `/var/log/maillog`. Default `/dev/stdout`.
+- `LOGOUTPUT` - Log file location. eg `/var/log/maillog`. Default `/dev/stdout`. See [Logging](#logging)
 - `TZ` - set timezone. This is used by Postfix to create `Received` headers. Default `UTC`.
+- `POSTFIX_EXPORTER_ENABLED` - enable the postfix_exporter. Default `false`. See [Postfix Exporter](#postfix-exporter)
 
 **General Postfix:**
 
@@ -88,6 +89,26 @@ POSTCONF=masquerade_domains=foo.example.com example.com;masquerade_exceptions=ro
 ```
 
 Would result in `masquerade_domains` and `masquerade_exceptions` being configured for Postfix.
+
+## Postfix Exporter
+
+This image comes with [kumina/postfix_exporter](https://github.com/kumina/postfix_exporter) pre-installed. To enable set the environment variable `POSTFIX_EXPORTER_ENABLED=true` (this must be exactly "true"). The exporter requires that the logoutput is `/dev/stdout` it can't be anything else.
+
+The exporter listens on port `9154/tcp`.
+
+See [Logging](#logging)
+
+## Logging
+
+This container outputs the postfix mail log to stdout by default, additionally logs are saved to `/var/log/s6-maillog/current` which is rotated every 10MB with only 3 log files retained.
+
+If you want to output somewhere else you can set environment variable `LOGOUTPUT`. For example `LOGOUTPUT=/var/log/maillog`.
+
+When enabled OpenDKIM only supports syslog output, the syslogd daemon is only used for OpenDKIM. Only /dev/stdout is supported for OpenDKIM syslog logs.
+
+_Note: the postfix exporter only works when the logs are left at /dev/stdout. This requirement of logs going to /dev/stdout is due to the containers logging structure. This may be improved but was needed to keep with backwards compatibility without adding additional variables to configured_
+
+_Note: The log `/var/log/s6-maillog/current` is always created but won't actually contain any logs if `LOGOUTPUT` is not `/dev/stdout`._
 
 ## Custom Scripts
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ This image is available on quay.io `quay.io/panubo/postfix` and AWS ECR Public `
 - `MYNETWORKS` - comma separated list of IP subnets that are allowed to relay. Default `127.0.0.0/8, 10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16`
 - `LOGOUTPUT` - Log file location. eg `/var/log/maillog`. Default `/dev/stdout`. See [Logging](#logging)
 - `TZ` - set timezone. This is used by Postfix to create `Received` headers. Default `UTC`.
-- `POSTFIX_EXPORTER_ENABLED` - enable the postfix_exporter. Default `false`. See [Postfix Exporter](#postfix-exporter)
+- `POSTFIX_EXPORTER_ENABLED` - enable the Prometheus postfix_exporter. Default `false`. See [Postfix Exporter](#postfix-prometheus-exporter)
 
 **General Postfix:**
 
@@ -90,7 +90,13 @@ POSTCONF=masquerade_domains=foo.example.com example.com;masquerade_exceptions=ro
 
 Would result in `masquerade_domains` and `masquerade_exceptions` being configured for Postfix.
 
-## Postfix Exporter
+**Config Reloader**
+
+The config reloader watches the known TLS cert and keys (`TLS_CRT`, `TLS_KEY` etc) for changes (`mv` or updated Kubernetes secret) then reloads Postfix.
+
+- `CONFIG_RELOADER_ENABLED` - Enable the config reloader. Default `false`, must be set to `true` to enable.
+
+## Postfix Prometheus Exporter
 
 This image comes with [kumina/postfix_exporter](https://github.com/kumina/postfix_exporter) pre-installed. To enable set the environment variable `POSTFIX_EXPORTER_ENABLED=true` (this must be exactly "true"). The exporter requires that the logoutput is `/dev/stdout` it can't be anything else.
 
@@ -100,13 +106,13 @@ See [Logging](#logging)
 
 ## Logging
 
-This container outputs the postfix mail log to stdout by default, additionally logs are saved to `/var/log/s6-maillog/current` which is rotated every 10MB with only 3 log files retained.
+This container outputs the Postfix mail log to stdout by default, additionally logs are saved to `/var/log/s6-maillog/current` which is rotated every 10MB with only 3 log files retained.
 
 If you want to output somewhere else you can set environment variable `LOGOUTPUT`. For example `LOGOUTPUT=/var/log/maillog`.
 
 When enabled OpenDKIM only supports syslog output, the syslogd daemon is only used for OpenDKIM. Only /dev/stdout is supported for OpenDKIM syslog logs.
 
-_Note: the postfix exporter only works when the logs are left at /dev/stdout. This requirement of logs going to /dev/stdout is due to the containers logging structure. This may be improved but was needed to keep with backwards compatibility without adding additional variables to configured_
+_Note: the Postfix Prometheus exporter only works when the logs are left at /dev/stdout. This requirement of logs going to /dev/stdout is due to the containers logging structure. This may be improved but was needed to keep with backwards compatibility without adding additional variables to configured_
 
 _Note: The log `/var/log/s6-maillog/current` is always created but won't actually contain any logs if `LOGOUTPUT` is not `/dev/stdout`._
 

--- a/s6/config-reloader/finish
+++ b/s6/config-reloader/finish
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+: "${CONFIG_RELOADER_ENABLED:=false}"
+
+if [[ "${CONFIG_RELOADER_ENABLED}" == "true" ]]; then
+  # Shutdown everything and exit the process crashes or is stopped.
+  s6-svscanctl -t /etc/s6
+fi

--- a/s6/config-reloader/run
+++ b/s6/config-reloader/run
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+# This script watches the known TLS cert and keys for changes (`mv` or updated Kubernetes secret) then reloads postfix.
+
+: "${CONFIG_RELOADER_ENABLED:=false}"
+
+if [[ "${CONFIG_RELOADER_ENABLED}" != "true" ]]; then
+  echo "config-reloader >> Config reloader is not being started"
+  s6-svc -d "$(pwd)"
+  exit
+fi
+
+watch_files=( 
+  "${TLS_CRT:-/etc/ssl/certs/ssl-cert-snakeoil.pem}" 
+  "${TLS_KEY:-/etc/ssl/private/ssl-cert-snakeoil.key}" 
+  "${CLIENT_TLS_KEY:-/etc/ssl/certs/ssl-cert-snakeoil.pem}" 
+  "${CLIENT_TLS_CRT:-/etc/ssl/private/ssl-cert-snakeoil.key}" 
+)
+
+# Start infinite loop
+while true; do
+  postfix reload
+  echo "config-reloader >> Waiting on config changes..."
+  # delete_self is the event that triggers when the link is removed and replaced.
+  inotifywait --event delete_self "${watch_files[@]}"
+  # sleep to prevent race condition
+  sleep 3
+done

--- a/s6/postfix/log/run
+++ b/s6/postfix/log/run
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+mkdir /var/log/s6-maillog
+chown postfix:postfix /var/log/s6-maillog
+
+exec s6-setuidgid postfix s6-log -bp 1 n3 s10000000 /var/log/s6-maillog

--- a/s6/postfix/run
+++ b/s6/postfix/run
@@ -7,6 +7,7 @@ set -e
 # Defaults
 : "${SIZELIMIT:=15728640}"  # 10Meg with headroom
 : "${RELAYHOST:=}" # empty
+: "${LOGOUTPUT:=/dev/stdout}"
 
 # TLS
 : "${USE_TLS:=yes}"
@@ -219,6 +220,10 @@ if [ ! -z "${SMTPD_USERS}" ]; then
   sed -i -E 's/etc\/host\.conf etc\/nsswitch\.conf etc\/nss_mdns\.config"/etc\/host.conf etc\/nsswitch.conf etc\/nss_mdns.config etc\/sasldb2"/' /usr/lib/postfix/configure-instance.sh
 fi
 
+# Configure logging
+echo "postfix >> Setting maillog_file to ${LOGOUTPUT}"
+postconf -e maillog_file="${LOGOUTPUT}"
+
 # Configure advanced settings
 if [ -n "${POSTCONF}" ]; then
   echo "postfix >> Configuring additional postfix parameters"
@@ -226,7 +231,7 @@ if [ -n "${POSTCONF}" ]; then
   IFS=';' read -ra CONFIG <<< "${POSTCONF}"
   for C in "${CONFIG[@]}"; do
       IFS='=' read -ra MAP <<< "$C"
-      echo "postfix >> Setting parameter ${MAP[0]}"
+      echo "postfix >> Setting parameter ${MAP[0]} to ${MAP[1]}"
       postconf -e "$C"
   done
 fi
@@ -241,5 +246,5 @@ rm -f /var/spool/postfix/pid/*
 echo "postfix >> Checking Postfix Configuration"
 postfix check
 
-# start postfix in foreground
+echo "postfix >> Starting postfix"
 exec /usr/sbin/postfix start-fg

--- a/s6/postfix_exporter/finish
+++ b/s6/postfix_exporter/finish
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+if [[ "${POSTFIX_EXPORTER_ENABLED}" == "true" ]]; then
+  # Shutdown everything and exit the process crashes or is stopped.
+  s6-svscanctl -t /etc/s6
+fi

--- a/s6/postfix_exporter/run
+++ b/s6/postfix_exporter/run
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+set -e
+
+[ "$DEBUG" == 'true' ] && set -x
+
+# Defaults
+: "${LOGOUTPUT:=/dev/stdout}"
+
+if [[ "${POSTFIX_EXPORTER_ENABLED}" == "true" ]] && [[ "${LOGOUTPUT}" != "/dev/stdout" ]]; then
+  echo "postfix_exporter >> FATAL exporter is enabled but requires LOGOUTPUT is set to /dev/stdout"
+  s6-svscanctl -t /etc/s6
+  exit 1
+elif [[ "${POSTFIX_EXPORTER_ENABLED}" == "true" ]]; then
+  s6-svwait -u /etc/s6/postfix/log
+  echo "postfix_exporter >> Starting postfix_exporter"
+  exec s6-setuidgid postfix postfix_exporter --postfix.logfile_path=/var/log/s6-maillog/current
+fi
+
+echo "postfix_exporter >> POSTFIX_EXPORTER_ENABLED not \"true\", not starting postfix_exporter"
+
+s6-svc -d "$(pwd)"
+exit

--- a/s6/syslogd/run
+++ b/s6/syslogd/run
@@ -4,9 +4,6 @@ set -e
 
 [ "$DEBUG" == 'true' ] && set -x
 
-# Defaults
-: "${LOGOUTPUT:=/dev/stdout}"
+echo "syslogd >> Setting syslogd output to /dev/stdout (Only used for OpenDKIM)"
 
-echo "syslogd >> Setting syslogd output to ${LOGOUTPUT}"
-
-exec syslogd -n -O "${LOGOUTPUT}" -S
+exec syslogd -n -O "/dev/stdout" -S


### PR DESCRIPTION
- Upgrade to debian 12 (Bookworm)
- Add postfix_exporter
- Switch postfix to use its own logging system instead of syslog
- Switch from third party s6 binaries to debian packaged s6
- Update Makefile
- Update README.md

We're attempting to reduce the reliance on syslogd. Recent versions of postfix can log directly to stdout or a file so we're making use of this. S6 also has a logging system that performs its own file rotation and can output to both a file and stdout (`s6-log`). Logging to a file is necessary to support the postfix_exporter which uses both the spool socket and mail logs. Unfortunately OpenDKIM only support syslog logging (hopefully this will change in the future and we can completely remove syslog).